### PR TITLE
Hepperle/contribs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Local code sandbox folders
+sb/

--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ We are a small group of self taught developers expanding our skillsets!
 
 Project Link: [https://github.com/codewizard13/udd-group-project-carpooly](https://github.com/codewizard13/udd-group-project-carpooly)
 
+---
+<div align="center">
+  <h4>OUR CONTRIBUTORS:</h4>
+  
+  <a href="https://github.com/codewizard13/udd-group-project-carpooly/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=codewizard13/udd-group-project-carpooly" />
+
+</div>
+
+---
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- MARKDOWN LINKS & IMAGES -->


### PR DESCRIPTION
- ADD "**Our Contributors**" section at the bottom of the readme, _**dynamically generated**_
- In GitHub contributors are listed to the right sidebar, but what if you are viewing the readme locally and not on GitHub? That is what this PR solves
- All can see at a glance who has contributed to this project
- Adds `sb/` folder to .gitignore (this is where you can create an sb/ folder on your local system to test out code ideas and not have to worry that they will accidentally be made public after a git push) 